### PR TITLE
Add md syntax to show build status from travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # lft-concept-api
 Standalone API template
 
+[![Build Status](https://travis-ci.org/LfT-Concept/lft-concept-api.svg?branch=master)](https://travis-ci.org/LfT-Concept/lft-concept-api)
+
 ## Set Up
 
 ### Starting from scratch


### PR DESCRIPTION
Added build icon reference. Note that this required switching on travis to watch this repo. But nothing configured for travis to actually create a build yet. That is another story. Resolves #6